### PR TITLE
Remove play.googleapis.com (Fix Google Play Store) and platform.twitter.com

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -287,7 +287,6 @@ pp.images.harmony.epsilon.com
 www.fost.me
 cdn.onesignal.com
 consent.cookiebot.com
-play.googleapis.com
 ea.pstmrk.it
 logger.unsplash.com
 cdn.lynda.com


### PR DESCRIPTION
Remove play.googleapis.com (Fix Google Play Store)