### PR TITLE
Remove platform.twitter.com

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -280,7 +280,6 @@ wa.me
 www.foodpanda.my
 edgewise.app
 googleadapis.l.google.com
-platform.twitter.com
 snowplow.trx.gitlab.net
 gemius.mgr.consensu.org
 pp.images.harmony.epsilon.com


### PR DESCRIPTION
Remove platform.twitter.com
This domain breaks some tweets embedded in articles in Google News app on Android